### PR TITLE
fix: Update target versions for OBS and Ubuntu

### DIFF
--- a/build-config
+++ b/build-config
@@ -1,2 +1,2 @@
-TARGETABLE_DISTROS=("mantic" "lunar" "jammy")
-TARGETABLE_VERSIONS=("30.0.2")
+TARGETABLE_DISTROS=("jammy" "noble" "oracular")
+TARGETABLE_VERSIONS=("30.2.3")

--- a/build-get-artefacts.sh
+++ b/build-get-artefacts.sh
@@ -18,7 +18,7 @@ DISTRO="${1}"
 case "${DISTRO}" in
     jammy) DISTRO_VER="22.04";;
     lunar) DISTRO_VER="23.04";;
-    mantic) DISTRO_VER="23.10";;
+    oracular) DISTRO_VER="24.10";;
     noble) DISTRO_VER="24.04";;
     *) echo "ERROR! Unknown Ubuntu release: ${DISTRO}"
       exit 1;;


### PR DESCRIPTION
fix: Updated target versions of OBS and Ubuntu in build-config to latest supported versions and updated the Ubuntu version check in build-get-artefacts.sh to check for newer currently supported Ubuntu versions. Removed build target for EOL Ubuntu versions 23.04 and 23.10 in both files to avoid errors during build as the apt repositories for those versions are no longer available and cause the build to fail