### PR TITLE
fix: Remove quotes from path in build-get-artefacts.sh

### DIFF
--- a/build-get-artefacts.sh
+++ b/build-get-artefacts.sh
@@ -35,8 +35,8 @@ fi
 case "${OBS_MAJ_VER}" in
     30)
         if [ -d "${BUILDS_DIR}/Builds/obs-builder-${DISTRO}/root/obs-${OBS_MAJ_VER}" ]; then
-            cp -v "${BUILDS_DIR}/Builds/obs-builder-${DISTRO}/root/obs-${OBS_MAJ_VER}/obs-portable-${OBS_VER}"*-ubuntu-"${DISTRO_VER}${SUFFIX}".* artefacts/
-            chown "${SUDO_USER}":"${SUDO_USER}" "artefacts/obs-portable-${OBS_VER}"*-ubuntu-"${DISTRO_VER}${SUFFIX}".*
+            cp -v ${BUILDS_DIR}/Builds/obs-builder-${DISTRO}/root/obs-${OBS_MAJ_VER}/obs-portable-${OBS_VER}*-ubuntu-"${DISTRO_VER}${SUFFIX}".* artefacts/
+            chown "${SUDO_USER}":"${SUDO_USER}" artefacts/obs-portable-${OBS_VER}*-ubuntu-"${DISTRO_VER}${SUFFIX}".*
         fi;;
     *) echo "ERROR! Unsupported OBS Studio version: ${OBS_VER}"
        exit 1;;


### PR DESCRIPTION
Removed the quotes on lines 38 and 39 as the wildcard * was being passed as part of the actual path instead of acting as a wildcard when it immediately followed the double quote encasing the first half of the obs builder path, causing the build to fail.