### PR TITLE
Update build-get-artefacts.sh to use find -exec

### DIFF
--- a/build-get-artefacts.sh
+++ b/build-get-artefacts.sh
@@ -35,8 +35,17 @@ fi
 case "${OBS_MAJ_VER}" in
     30)
         if [ -d "${BUILDS_DIR}/Builds/obs-builder-${DISTRO}/root/obs-${OBS_MAJ_VER}" ]; then
-            cp -v ${BUILDS_DIR}/Builds/obs-builder-${DISTRO}/root/obs-${OBS_MAJ_VER}/obs-portable-${OBS_VER}*-ubuntu-"${DISTRO_VER}${SUFFIX}".* artefacts/
-            chown "${SUDO_USER}":"${SUDO_USER}" artefacts/obs-portable-${OBS_VER}*-ubuntu-"${DISTRO_VER}${SUFFIX}".*
+            # Set source pattern to pass to find
+            SOURCE_PATTERN="${BUILDS_DIR}/Builds/obs-builder-${DISTRO}/root/obs-${OBS_MAJ_VER}/obs-portable-${OBS_VER}*-ubuntu-${DISTRO_VER}${SUFFIX}.*"
+
+            # Use find to handle safe expansion of filenames matching the pattern instead and pass the filenames to cp with -exec
+            find $(dirname "$SOURCE_PATTERN") -type f -name "$(basename "$SOURCE_PATTERN")" -exec cp -v {} artefacts/ \;
+            # Use find again but for chown as wildcards were also not being handled safely here.
+            find artefacts/ -type f -name "obs-portable-${OBS_VER}*-ubuntu-${DISTRO_VER}${SUFFIX}.*" -exec chown "${SUDO_USER}:${SUDO_USER}" {} \;
+            
+            # Old format that caused 'No such file or directory' error with both cp and chown. Keeping this here just in case.
+            # cp -v ${BUILDS_DIR}/Builds/obs-builder-${DISTRO}/root/obs-${OBS_MAJ_VER}/obs-portable-${OBS_VER}*-ubuntu-"${DISTRO_VER}${SUFFIX}".* artefacts/
+            # chown "${SUDO_USER}":"${SUDO_USER}" artefacts/obs-portable-${OBS_VER}*-ubuntu-"${DISTRO_VER}${SUFFIX}".*
         fi;;
     *) echo "ERROR! Unsupported OBS Studio version: ${OBS_VER}"
        exit 1;;


### PR DESCRIPTION
Placed `cp` and `chown` within `find -exec` to allow find to handle safe expansion of filenames using wildcards instead of passing wildcards directly to the commands, as that causes them to both process * as part of the path causing a `No such file or directory` error when parsing.