### PR TITLE
fix: Parse wildcard in path safely with find to allow workflow to upload new builds properly

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -74,9 +74,8 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        for artefact in "artefacts/obs-portable-${{ matrix.version }}"*; do
-          gh release upload "${{ github.ref }}" "${artefact}" --clobber
-        done
+        find artefacts/ -type f -name "obs-portable-${{ matrix.version }}*" -exec gh release upload "${{ github.ref }}" {} --clobber \;
+
 
   publish-release:
     name: Publish release


### PR DESCRIPTION
Fixed issue where path with wildcard in for loop was being interpreted as part of the path causing the workflow to fail when attempting to upload the files to the release on github.