### PR TITLE
Update simplyGray to V2 and use unzip instead of unrar

### DIFF
--- a/builder/obs-build.sh
+++ b/builder/obs-build.sh
@@ -424,8 +424,8 @@ function stage_07_scripts() {
 function stage_08_themes() {
     download_file "https://obsproject.com/forum/resources/yami-resized.1611/version/5246/download" "${DIR_DOWNLOAD}/Yami-Resized-1.2.zip"
     unzip -o -qq "${DIR_DOWNLOAD}/Yami-Resized-1.2.zip" -d "${DIR_INSTALL}/data/obs-studio/themes"
-    download_file "https://obsproject.com/forum/resources/simplygray-dark-theme-with-customizable-highlight-color.1598/download" "${DIR_DOWNLOAD}/simplyGray1.3.2.rar"
-    unrar e "${DIR_DOWNLOAD}/simplyGray1.3.2.rar" "${DIR_INSTALL}/data/obs-studio/themes/"
+    download_file "https://obsproject.com/forum/resources/simplygray-dark-theme-with-customizable-highlight-color.1598/download" "${DIR_DOWNLOAD}/simplyGrayV2.zip"
+    unzip -o -qq "${DIR_DOWNLOAD}/simplyGrayV2.zip" -d "${DIR_INSTALL}/data/obs-studio/themes"
 }
 
 function stage_09_finalise() {


### PR DESCRIPTION
Changed unrar to unzip as simplyGray is updated to V2 and is now a zip archive instead of a rar archive

unrar returned the following error when attempting to unpack the theme
```
UNRAR 7.00 freeware      Copyright (c) 1993-2024 Alexander Roshal
/root/obs-30/downloads/simplyGray1.3.2.rar is not RAR archive
No files to extract
Container noble failed with error code 1.
```